### PR TITLE
fix: replace non-existent `font-lock-reference-face`

### DIFF
--- a/ipl-mode.el
+++ b/ipl-mode.el
@@ -178,7 +178,7 @@
                 ))
             ("\"[^\"]+\"" . font-lock-string-face)
             ("'[^']+'" . font-lock-string-face)
-            ("[^A-Za-z0-9.]\\([A-Z][A-Za-z0-9.]+\\)\\." . ((1 font-lock-reference-face)))
+            ("[^A-Za-z0-9.]\\([A-Z][A-Za-z0-9.]+\\)\\." . ((1 font-lock-constant-face)))
             (,(regexp-opt ipl-keywords 'words) . font-lock-keyword-face)
             (,(regexp-opt ipl-builtins ) . font-lock-builtin-face)))
     (setq font-lock-defaults '(ipl-highlights))


### PR DESCRIPTION
`font-lock-reference-face` is removed in recent Emacs (at least by version 29.1). Use `font-lock-constant-face` instead.